### PR TITLE
refactor(httpx): replace panic with errors.ErrUnsupported

### DIFF
--- a/httpx/extractor/value.go
+++ b/httpx/extractor/value.go
@@ -2,6 +2,7 @@ package extractor
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 )
@@ -127,7 +128,7 @@ func (b baseValueExtractor[T]) String() string {
 }
 
 // FromRequest is a placeholder implementation that should be overridden by embedding types.
-// It will panic if called directly.
+// It returns an error indicating that the method is not supported.
 func (b *baseValueExtractor[T]) FromRequest(*http.Request) error {
-	panic("not implemented")
+	return errors.ErrUnsupported
 }

--- a/httpx/extractor/value_test.go
+++ b/httpx/extractor/value_test.go
@@ -232,14 +232,3 @@ func TestValueConversions(t *testing.T) {
 		})
 	}
 }
-
-func TestBaseValueExtractorPanic(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic but got nil")
-		}
-	}()
-
-	extractor := baseValueExtractor[TestValue]{}
-	_ = extractor.FromRequest(nil)
-}


### PR DESCRIPTION
Replaces the runtime panic in baseValueExtractor.FromRequest with errors.ErrUnsupported. This prevents potential runtime crashes and aligns with safer error handling practices for unimplemented methods.